### PR TITLE
Problems creating the assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "babel-loader": "^7.1.5",
     "babel-preset-latest": "^6.24.0",
     "css-loader": "^0.28.11",
-    "extract-text-webpack-plugin": "^3.0.2",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "less": "^2.7.2",
     "less-loader": "^3.0.0",
     "less-plugin-clean-css": "^1.5.1",


### PR DESCRIPTION
To fix the problem with the assets bundle, the extract-text-webpack-plugin had to be updated to the next major version with the @next switch. This fixes the bundle error I had (and I also see on your DigitalOcean installation: Error 404 on app.js / style.css). The command needed is:
```
npm install extract-text-webpack-plugin@next
```

this fixes the problem for those who only want to update instead of a fresh clone or pull.