### PR TITLE
Fix variant for tests/bootstrap.php file

### DIFF
--- a/frontend/web/index-test.php
+++ b/frontend/web/index-test.php
@@ -1,13 +1,18 @@
 <?php
+
+// Composer
+require __DIR__ . '/../../vendor/autoload.php';
+
+// Helpers
+require_once(__DIR__ . '/../../common/helpers.php');
+
+// Environment
 require(__DIR__ . '/../../tests/bootstrap.php');
 
 // NOTE: Make sure this file is not accessible when deployed to production
 if (YII_ENV !== 'test') {
     die('You are not allowed to access this file.');
 }
-
-// Environment
-require(__DIR__ . '/../../common/env.php');
 
 // Yii
 require(__DIR__ . '/../../vendor/yiisoft/yii2/Yii.php');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,13 +2,6 @@
 /**
  * @author Eugene Terentev <eugene@terentev.net>
  */
-// Composer
-require __DIR__ . '/../vendor/autoload.php';
-
-// Set environment
-defined('YII_DEBUG') or define('YII_DEBUG', true);
-defined('YII_ENV') or define('YII_ENV', 'test');
-defined('YII_APP_BASE_PATH') or define('YII_APP_BASE_PATH', dirname(__DIR__));
 
 // Environment
 $dotenv = new \Dotenv\Dotenv(dirname(__DIR__));
@@ -16,3 +9,8 @@ $dotenv->load();
 $dotenv->required('TEST_DB_DSN');
 $dotenv->required('TEST_DB_USERNAME');
 $dotenv->required('TEST_DB_PASSWORD');
+
+// Set environment
+defined('YII_DEBUG') or define('YII_DEBUG', true);
+defined('YII_ENV') or define('YII_ENV', env('YII_ENV', 'test'));
+defined('YII_APP_BASE_PATH') or define('YII_APP_BASE_PATH', dirname(__DIR__));


### PR DESCRIPTION
This fixes ability to use index-test.php even if YII_ENV === 'prod' in .env file.
The reason is the wrong sequence of require statements in /tests/bootstrap.php file.
Review and merge, please. 