### PR TITLE
Ensures that on windows sh files won't have CR LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,8 @@
 *.sql  text
 *.xml  text
 *.yml  text
+# Ensures that on windows sh files won't have CR LF that breaks docker-compose
+*.sh   text eol=lf
 
 # Ensure those won't be messed up with
 *.png  binary

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "build:app": [
       "@composer install",
       "echo 'waiting for mysql' && sleep 10",
-      "console/yii app/setup --interactive=0"
+      "php console/yii app/setup --interactive=0"
     ],
     "docker:build": [
       "@build:env",


### PR DESCRIPTION
Ensures that on windows sh files won't have CR LF that breaks docker-compose on default git configuration.
Fix for /usr/bin/env: 'php\r' error on first `composer run-script docker:build` run.