### PR TITLE
#741 - Couldn't find env file: C:\Users\fanto...myproject.com\.env Closes #741

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ composer create-project yii2-starter-kit/yii2-starter-kit myproject.com
 
 ## Docker installation
 1. Install [docker](https://docs.docker.com/engine/installation/), [docker-compose](https://docs.docker.com/compose/install/) and [composer](https://getcomposer.org/) to your system
-2. Run ``composer run-script docker:start``
+2. Run ``composer run-script docker:build``
 3. That's all - your application is accessible on [http://yii2-starter-kit.localhost](http://yii2-starter-kit.localhost)
 
  * - docker host IP address may vary on Windows and MacOS systems


### PR DESCRIPTION
fix documentation, without using `build` param command, using `start` instead, the app is in state, when the .env file is not copied yet from the .env.dist and the user following the docs ends up with the error above