### PR TITLE
Enable maintenance mode in production (without .env configuration)

### DIFF
--- a/api/config/web.php
+++ b/api/config/web.php
@@ -17,7 +17,7 @@ $config = [
                 if (env('APP_MAINTENANCE') === '1') {
                     return true;
                 }
-                return $app->keyStorage->get('frontend.maintenance') === 'enabled';
+                return $app->keyStorage->get('frontend.maintenance', 'disabled', false) === 'enabled';
             }
         ],
         'request' => [

--- a/frontend/config/web.php
+++ b/frontend/config/web.php
@@ -43,7 +43,7 @@ $config = [
                 if (env('APP_MAINTENANCE') === '1') {
                     return true;
                 }
-                return $app->keyStorage->get('frontend.maintenance') === 'enabled';
+                return $app->keyStorage->get('frontend.maintenance', 'disabled', false) === 'enabled';
             }
         ],
         'request' => [


### PR DESCRIPTION
In production mode, the switch function in the admin panel does not work due to the fact that the variable is cached.